### PR TITLE
Add mutation address to mutation cards

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -47,6 +47,10 @@ th {
   padding: 0.5rem;
 }
 
+.card-body .address {
+  font-size: 10px;
+}
+
 .btn-primary {
   background-color: #002C81;
   border-color: #002C81;

--- a/static/js/component.boite-accordeon.js
+++ b/static/js/component.boite-accordeon.js
@@ -12,6 +12,7 @@ Vue.component('boite-accordeon', {
 						<div class="media-body text-left ml-1">
 							<b>{{ formatterNombre(mutation.infos[0]['valeur_fonciere']) }} € / {{ mutation.infos[0]['nature_mutation'] }}</b><br>
 							<span>{{ mutation.infos[0]['date_mutation'] }}</span>
+							<div class="address">{{ formatterAdresseNumero(mutation.infos[0]['adresse_numero']) }}{{ formatterSuffixe(mutation, mutation.infos[0]['adresse_suffixe']) }} {{ mutation.infos[0]['adresse_nom_voie'] }}</div>
 			 			</div>
 						<div v-if="vue.mutationIndex != index" class="ml-1 mr-1">
 							<i class="fas fa-sort-down fa-1x"></i>
@@ -45,4 +46,14 @@ Vue.component('boite-accordeon', {
 
 function formatterNombre(nombreDecimal) {
 	return nombreDecimal.replace(/\..*/g, '').replace(/(\d)(?=(\d{3})+$)/g, '$1 ');
+}
+
+function formatterAdresseNumero(nombreDecimal) {
+    return nombreDecimal.replace(/\..*/g, '');
+}
+
+function formatterSuffixe(mutation, adresse_suffixe) {
+	if (!adresse_suffixe.match(/none/i)) {
+		return adresse_suffixe;
+	}
 }

--- a/static/js/data.js
+++ b/static/js/data.js
@@ -114,7 +114,7 @@ function computeParcelle(mutationsSection, idParcelle) {
 	var mutations = _.chain(mutationsParcelle)
 		.groupBy('id_mutation')
 		.map(function (rows, idMutation) {
-			var infos = [_.pick(rows[0], 'date_mutation', 'id_parcelle', 'nature_mutation', 'valeur_fonciere')]
+			var infos = [_.pick(rows[0], 'date_mutation', 'id_parcelle', 'nature_mutation', 'valeur_fonciere', 'adresse_numero', 'adresse_suffixe', 'adresse_nom_voie')]
 
 			var parcellesLiees = _.uniq(
 				mutationsSection


### PR DESCRIPTION
Je trouve dommage que l'adresse n'apparaisse pas alors qu'elle est disponible.

Donc, voici l'ajout de l'adresse dans la fiche affichant une mutation.

![Screenshot_2019-05-13 DVF](https://user-images.githubusercontent.com/3259059/57588999-a4268500-751d-11e9-84c1-9c2ef62fabc5.png)

Basé sur les colonnes `adresse_numero`, `adresse_suffixe`, `adresse_nom_voie`

Après je constate que `adresse_numero` semble fréquemment erroné.
Je remarque fréquemment des valeurs excessivement grandes.

Bien cordialement,

